### PR TITLE
moved temporary file ~/.AttachedDevices to /tmp/AttachedDevices

### DIFF
--- a/devices/e45/ubuntu/rc-proposedkeep.sh
+++ b/devices/e45/ubuntu/rc-proposedkeep.sh
@@ -14,9 +14,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -43,7 +43,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-krillin.img
     echo ""
     sleep 1
@@ -53,7 +53,7 @@ fi
   else
     echo "Device not found"
     sleep 1
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     echo "Back to menu"
     sleep 1

--- a/devices/e45/ubuntu/rc-proposedwipe.sh
+++ b/devices/e45/ubuntu/rc-proposedwipe.sh
@@ -14,9 +14,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -38,7 +38,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-krillin.img
     echo ""
     sleep 1
@@ -48,7 +48,7 @@ fi
   else
     echo "Device not found"
     sleep 1
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     echo "Back to menu"
     sleep 1

--- a/devices/e45/ubuntu/screencast.sh
+++ b/devices/e45/ubuntu/screencast.sh
@@ -29,11 +29,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -163,7 +163,7 @@ fi
 ssh $SSH_OPTS -C -c aes128-ctr phablet@localhost mirscreencast -m /var/run/mir_socket --stdout --cap-interval 10 -s 360 640 |  mplayer -framedrop -demuxer rawvideo -rawvideo fps=6:w=360:h=640:format=rgba -
 echo ""
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -174,7 +174,7 @@ sleep 2
 
 else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo "Back to menu"
     sleep 1

--- a/devices/e45/ubuntu/stablekeep.sh
+++ b/devices/e45/ubuntu/stablekeep.sh
@@ -14,9 +14,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -43,7 +43,7 @@ sleep 1
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-krillin.img
     echo ""
     sleep 1
@@ -53,7 +53,7 @@ sleep 1
   else
     echo "Device not found"
     sleep 1
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     echo "Back to menu"
     sleep 1

--- a/devices/e45/ubuntu/stablewipe.sh
+++ b/devices/e45/ubuntu/stablewipe.sh
@@ -14,9 +14,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -38,7 +38,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-krillin.img
     echo ""
     sleep 1
@@ -49,7 +49,7 @@ fi
     echo "Device not found"
     sleep 1
     echo ""
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo "Back to menu"
     sleep 1
     . ./launcher.sh

--- a/devices/e5hd/ubuntu/rc-proposedkeep.sh
+++ b/devices/e5hd/ubuntu/rc-proposedkeep.sh
@@ -14,9 +14,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices >/tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -43,7 +43,7 @@ sleep 1
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-vegetahd.img
     echo ""
     sleep 1
@@ -53,7 +53,7 @@ sleep 1
   else
     echo "Device not found"
     sleep 1
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     echo "Back to menu"
     sleep 1

--- a/devices/e5hd/ubuntu/rc-proposedwipe.sh
+++ b/devices/e5hd/ubuntu/rc-proposedwipe.sh
@@ -14,9 +14,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -38,7 +38,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-vegetahd.img
     echo ""
     sleep 1
@@ -47,7 +47,7 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/e5hd/ubuntu/screencast.sh
+++ b/devices/e5hd/ubuntu/screencast.sh
@@ -29,11 +29,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices >/tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -162,7 +162,7 @@ fi
 ssh $SSH_OPTS -C -c aes128-ctr phablet@localhost mirscreencast -m /var/run/mir_socket --stdout --cap-interval 10 -s 360 640 |  mplayer -framedrop -demuxer rawvideo -rawvideo fps=6:w=360:h=640:format=rgba -
 echo ""
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -173,7 +173,7 @@ sleep 2
 else
       echo "Device not found"
       sleep 1
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo "Back to menu"
     sleep 1
     . ./launcher.sh

--- a/devices/e5hd/ubuntu/stablekeep.sh
+++ b/devices/e5hd/ubuntu/stablekeep.sh
@@ -14,9 +14,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -43,7 +43,7 @@ sleep 1
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-vegetahd.img
     echo ""
     sleep 1
@@ -53,7 +53,7 @@ sleep 1
   else
     echo "Device not found"
     sleep 1
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     echo "Back to menu"
     sleep 1

--- a/devices/e5hd/ubuntu/stablewipe.sh
+++ b/devices/e5hd/ubuntu/stablewipe.sh
@@ -14,9 +14,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -38,7 +38,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-vegetahd.img
     echo ""
     sleep 1
@@ -49,7 +49,7 @@ fi
     echo "Device not found"
     sleep 1
     echo ""
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo "Back to menu"
     sleep 1
     . ./launcher.sh

--- a/devices/fairphone2/ubuntu/stablewipe.sh
+++ b/devices/fairphone2/ubuntu/stablewipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/generic/android/backup.sh
+++ b/devices/generic/android/backup.sh
@@ -23,9 +23,9 @@ if [ "$broption" = "1" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
   fi
-  if grep 'device$\|device$' ~/.AttachedDevices
+  if grep 'device$\|device$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -44,14 +44,14 @@ if [ "$broption" = "1" ]; then
   echo ""
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
     sleep 1
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"
@@ -72,9 +72,9 @@ elif [ "$broption" = "2" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices >/tmp/AttachedDevices
   fi
-  if grep 'device$\|device$' ~/.AttachedDevices
+  if grep 'device$\|device$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -85,14 +85,14 @@ elif [ "$broption" = "2" ]; then
   echo ""
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
     sleep 1
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/generic/ubuntu/openstore.sh
+++ b/devices/generic/ubuntu/openstore.sh
@@ -14,11 +14,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -38,7 +38,7 @@ echo "done"
 echo ""
 sleep 3
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -48,7 +48,7 @@ sleep 2
 else
       echo "Device not found"
       sleep 1
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo "Back to menu"
     sleep 1
     . ./launcher.sh

--- a/devices/m10fhd/ubuntu/rc-proposedkeep.sh
+++ b/devices/m10fhd/ubuntu/rc-proposedkeep.sh
@@ -18,11 +18,11 @@ if [ "$developermode"==Y -o "$developermode"==y -o "$developermode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
   echo ""
   sleep 1
-  if grep 'device$\|device$' ~/.AttachedDevices
+  if grep 'device$\|device$' /tmp/AttachedDevices
   then
     echo ""
     echo "Device detected !"
@@ -52,7 +52,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-frieza.img
     echo ""
     sleep 1
@@ -62,7 +62,7 @@ fi
   else
     echo "Device not found"
     echo ""
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo "Back to menu"
   sleep 1

--- a/devices/m10fhd/ubuntu/rc-proposedwipe.sh
+++ b/devices/m10fhd/ubuntu/rc-proposedwipe.sh
@@ -19,11 +19,11 @@ clear
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -46,7 +46,7 @@ clear
       sleep 1
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       #rm recovery-frieza.img
       echo ""
       sleep 1
@@ -55,7 +55,7 @@ clear
       exit
     else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       sleep 1
       echo "Back to menu"

--- a/devices/m10fhd/ubuntu/screencast.sh
+++ b/devices/m10fhd/ubuntu/screencast.sh
@@ -29,11 +29,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -162,7 +162,7 @@ fi
 ssh $SSH_OPTS -C -c aes128-ctr phablet@localhost mirscreencast -m /var/run/mir_socket --stdout --cap-interval 10 -s 625 1000 |  mplayer -vf rotate=2 -framedrop -demuxer rawvideo -rawvideo fps=6:w=625:h=1000:format=rgba -
 echo ""
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -172,7 +172,7 @@ sleep 2
 [ -n "$SSH_RUNNING" ] || toggle_ssh false
 else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo "Back to menu"
     sleep 1

--- a/devices/m10fhd/ubuntu/stablekeep.sh
+++ b/devices/m10fhd/ubuntu/stablekeep.sh
@@ -18,11 +18,11 @@ if [ "$developermode"==Y -o "$developermode"==y -o "$developermode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
   echo ""
   sleep 1
-  if grep 'device$\|device$' ~/.AttachedDevices
+  if grep 'device$\|device$' /tmp/AttachedDevices
   then
     echo ""
     echo "Device detected !"
@@ -52,7 +52,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-frieza.img
     echo ""
     sleep 1
@@ -61,7 +61,7 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Back to menu"

--- a/devices/m10fhd/ubuntu/stablewipe.sh
+++ b/devices/m10fhd/ubuntu/stablewipe.sh
@@ -19,11 +19,11 @@ clear
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -46,7 +46,7 @@ clear
       sleep 1
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       #rm recovery-frieza.img
       echo ""
       sleep 1
@@ -55,7 +55,7 @@ clear
       exit
     else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo "Back to menu"
     sleep 1

--- a/devices/m10hd/ubuntu/rc-proposedkeep.sh
+++ b/devices/m10hd/ubuntu/rc-proposedkeep.sh
@@ -18,11 +18,11 @@ if [ "$developermode"==Y -o "$developermode"==y -o "$developermode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
   echo ""
   sleep 1
-  if grep 'device$\|device$' ~/.AttachedDevices
+  if grep 'device$\|device$' /tmp/AttachedDevices
   then
     echo ""
     echo "Device detected !"
@@ -52,7 +52,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-cooler.img
     echo ""
     sleep 1
@@ -61,7 +61,7 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Back to menu"

--- a/devices/m10hd/ubuntu/rc-proposedwipe.sh
+++ b/devices/m10hd/ubuntu/rc-proposedwipe.sh
@@ -19,11 +19,11 @@ clear
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -46,7 +46,7 @@ clear
       sleep 1
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       #rm recovery-cooler.img
       echo ""
       sleep 1
@@ -55,7 +55,7 @@ clear
       exit
     else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       sleep 1
       echo "Back to menu"

--- a/devices/m10hd/ubuntu/screencast.sh
+++ b/devices/m10hd/ubuntu/screencast.sh
@@ -29,11 +29,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -162,7 +162,7 @@ fi
 ssh $SSH_OPTS -C -c aes128-ctr phablet@localhost mirscreencast -m /var/run/mir_socket --stdout --cap-interval 10 -s 625 1000 |  mplayer -vf rotate=2 -framedrop -demuxer rawvideo -rawvideo fps=6:w=625:h=1000:format=rgba -
 echo ""
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -172,7 +172,7 @@ sleep 2
 [ -n "$SSH_RUNNING" ] || toggle_ssh false
 else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo "Back to menu"
     sleep 1

--- a/devices/m10hd/ubuntu/stablekeep.sh
+++ b/devices/m10hd/ubuntu/stablekeep.sh
@@ -18,11 +18,11 @@ if [ "$developermode"==Y -o "$developermode"==y -o "$developermode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
   echo ""
   sleep 1
-  if grep 'device$\|device$' ~/.AttachedDevices
+  if grep 'device$\|device$' /tmp/AttachedDevices
   then
     echo ""
     echo "Device detected !"
@@ -52,7 +52,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-cooler.img
     echo ""
     sleep 1
@@ -61,7 +61,7 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Back to menu"

--- a/devices/m10hd/ubuntu/stablewipe.sh
+++ b/devices/m10hd/ubuntu/stablewipe.sh
@@ -19,11 +19,11 @@ clear
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -46,7 +46,7 @@ clear
       sleep 1
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       #rm recovery-cooler.img
       echo ""
       sleep 1
@@ -55,7 +55,7 @@ clear
       exit
     else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo "Back to menu"
     sleep 1

--- a/devices/mx4/android/cyanogenmod.sh
+++ b/devices/mx4/android/cyanogenmod.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -61,9 +61,9 @@ fi
       echo "Detecting device"
       echo ""
       sleep 1
-      adb devices >~/.AttachedDevices
+      adb devices >/tmp/AttachedDevices
     fi
-    if grep 'device$\|recovery$' ~/.AttachedDevices
+    if grep 'device$\|recovery$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -106,14 +106,14 @@ fi
         sleep 5
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         sleep 1
         echo "Exiting script. Bye Bye"
         sleep 1
       else
         echo "Device not found"
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         sleep 1
         echo ""
         echo "Back to menu"
@@ -122,7 +122,7 @@ fi
     fi
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/mx4/android/cyanogenmodwogapps.sh
+++ b/devices/mx4/android/cyanogenmodwogapps.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -57,9 +57,9 @@ fi
       echo "Detecting device"
       echo ""
       sleep 1
-      adb devices >~/.AttachedDevices
+      adb devices >/tmp/AttachedDevices
     fi
-    if grep 'device$\|recovery$' ~/.AttachedDevices
+    if grep 'device$\|recovery$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -95,14 +95,14 @@ fi
         sleep 5
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         sleep 1
         echo "Exiting script. Bye Bye"
         sleep 1
       else
         echo "Device not found"
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         sleep 1
         echo ""
         echo "Back to menu"
@@ -111,7 +111,7 @@ fi
     fi
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/mx4/ubuntu/rc-proposedkeep.sh
+++ b/devices/mx4/ubuntu/rc-proposedkeep.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -42,7 +42,7 @@ sleep 1
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-arale.img
     echo ""
     sleep 1
@@ -52,7 +52,7 @@ sleep 1
   else
     echo "Device not found"
     sleep 1
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     echo "Back to menu"
     sleep 1

--- a/devices/mx4/ubuntu/rc-proposedwipe.sh
+++ b/devices/mx4/ubuntu/rc-proposedwipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -39,7 +39,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-arale.img
     echo ""
     sleep 1
@@ -48,7 +48,7 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/mx4/ubuntu/screencast.sh
+++ b/devices/mx4/ubuntu/screencast.sh
@@ -29,11 +29,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -162,7 +162,7 @@ fi
 ssh $SSH_OPTS -C -c aes128-ctr phablet@localhost mirscreencast -m /var/run/mir_socket --stdout --cap-interval 10 -s 360 640 |  mplayer -framedrop -demuxer rawvideo -rawvideo fps=6:w=360:h=640:format=rgba -
 echo ""
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -172,7 +172,7 @@ sleep 2
 [ -n "$SSH_RUNNING" ] || toggle_ssh false
 else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo "Back to menu"
     sleep 1

--- a/devices/mx4/ubuntu/stablekeep.sh
+++ b/devices/mx4/ubuntu/stablekeep.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -42,7 +42,7 @@ sleep 1
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-arale.img
     echo ""
     sleep 1
@@ -52,7 +52,7 @@ sleep 1
   else
     echo "Device not found"
     sleep 1
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     echo "Back to menu"
     sleep 1

--- a/devices/mx4/ubuntu/stablewipe.sh
+++ b/devices/mx4/ubuntu/stablewipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -39,7 +39,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-arale.img
     echo ""
     sleep 1
@@ -48,7 +48,7 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus10/android/bootloader.sh
+++ b/devices/nexus10/android/bootloader.sh
@@ -22,9 +22,9 @@ if [ "$ulbootloader" = "1" ]; then
     echo "Detecting device"
     echo ""
     sleep 1
-    fastboot devices >~/.AttachedDevices
+    fastboot devices > /tmp/AttachedDevices
   fi
-    if grep 'device$\|fastboot$' ~/.AttachedDevices
+    if grep 'device$\|fastboot$' /tmp/AttachedDevices
     then
       echo "Device detected !"
       sleep 1
@@ -36,7 +36,7 @@ if [ "$ulbootloader" = "1" ]; then
       echo "Bootloader locked"
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       echo "Exiting script. Bye Bye"
       sleep 1
@@ -56,9 +56,9 @@ elif [ "$ulbootloader" = "2" ]; then
       echo "Detecting device"
       echo ""
       sleep 1
-      fastboot devices >~/.AttachedDevices
+      fastboot devices >/tmp/AttachedDevices
     fi
-      if grep 'device$\|fastboot$' ~/.AttachedDevices
+      if grep 'device$\|fastboot$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -73,7 +73,7 @@ elif [ "$ulbootloader" = "2" ]; then
         echo "Bootloader unlocked"
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         echo "Exiting script. Bye Bye"
         sleep 1
@@ -86,5 +86,5 @@ fi
 
 else
   echo "Device not found."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
   exit

--- a/devices/nexus10/android/cyanogenmod.sh
+++ b/devices/nexus10/android/cyanogenmod.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -99,7 +99,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -107,7 +107,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus10/android/cyanogenmodwogapps.sh
+++ b/devices/nexus10/android/cyanogenmodwogapps.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -87,7 +87,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -95,7 +95,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus10/android/factoryimage.sh
+++ b/devices/nexus10/android/factoryimage.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -44,7 +44,7 @@ fi
     sleep 2
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     rm -rf ./mantaray-lmy49j
     #rm -f ./*.tgz
     echo ""
@@ -54,6 +54,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus10/android/phoenixos.sh
+++ b/devices/nexus10/android/phoenixos.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -46,7 +46,7 @@ fi
     sleep 2
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     rm -rf ./Phoenix-neuxs10-1.0.5-beta
     #rm -f ./*.tgz
     echo ""
@@ -56,6 +56,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus10/android/twrp.sh
+++ b/devices/nexus10/android/twrp.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -33,7 +33,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm -f ./*.img
     echo ""
     sleep 1
@@ -42,6 +42,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus10/ubuntu/stablewipe.sh
+++ b/devices/nexus10/ubuntu/stablewipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus4/android/bootloader.sh
+++ b/devices/nexus4/android/bootloader.sh
@@ -23,9 +23,9 @@ if [ "$ulbootloader" = "1" ]; then
     echo "Detecting device"
     echo ""
     sleep 1
-    fastboot devices >~/.AttachedDevices
+    fastboot devices > /tmp/AttachedDevices
   fi
-    if grep 'device$\|fastboot$' ~/.AttachedDevices
+    if grep 'device$\|fastboot$' /tmp/AttachedDevices
     then
       echo "Device detected !"
       sleep 1
@@ -37,7 +37,7 @@ if [ "$ulbootloader" = "1" ]; then
       echo "Bootloader locked"
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       echo "Exiting script. Bye Bye"
       sleep 1
@@ -58,9 +58,9 @@ elif [ "$ulbootloader" = "2" ]; then
       echo "Detecting device"
       echo ""
       sleep 1
-      fastboot devices >~/.AttachedDevices
+      fastboot devices >/tmp/AttachedDevices
     fi
-      if grep 'device$\|fastboot$' ~/.AttachedDevices
+      if grep 'device$\|fastboot$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -75,19 +75,19 @@ elif [ "$ulbootloader" = "2" ]; then
         echo "Bootloader unlocked"
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         echo "Exiting script. Bye Bye"
         sleep 1
         exit
       fi
   elif [ "$ulbootloader" = "3" ]; then
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo "Quit"
       echo "Exiting script. Bye Bye"
 fi
 
 else
   echo "Device not found."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
   exit

--- a/devices/nexus4/android/cyanogenmod.sh
+++ b/devices/nexus4/android/cyanogenmod.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -99,7 +99,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -107,7 +107,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus4/android/cyanogenmodwogapps.sh
+++ b/devices/nexus4/android/cyanogenmodwogapps.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices >/tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -87,7 +87,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -95,7 +95,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus4/android/factoryimage.sh
+++ b/devices/nexus4/android/factoryimage.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -39,7 +39,7 @@ fi
     sleep 2
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     rm -rf ./occam-lmy48t
     #rm -f ./*.tgz
     echo ""
@@ -49,6 +49,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus4/android/twrp.sh
+++ b/devices/nexus4/android/twrp.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -33,7 +33,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm -f ./*.img
     echo ""
     sleep 1
@@ -42,6 +42,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus4/ubuntu/rc-proposedkeep.sh
+++ b/devices/nexus4/ubuntu/rc-proposedkeep.sh
@@ -14,9 +14,9 @@ if [ "$recoverymode"==Y -o "$recoverymode"==y -o "$recoverymode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|recovery$' ~/.AttachedDevices
+if grep 'device$\|recovery$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -31,14 +31,14 @@ if grep 'device$\|recovery$' ~/.AttachedDevices
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
     sleep 1
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus4/ubuntu/rc-proposedwipe.sh
+++ b/devices/nexus4/ubuntu/rc-proposedwipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus4/ubuntu/screencast.sh
+++ b/devices/nexus4/ubuntu/screencast.sh
@@ -29,11 +29,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -162,7 +162,7 @@ fi
 ssh $SSH_OPTS -C -c aes128-ctr phablet@localhost mirscreencast -m /var/run/mir_socket --stdout --cap-interval 10 -s 360 640 |  mplayer -framedrop -demuxer rawvideo -rawvideo fps=6:w=360:h=640:format=rgba -
 echo ""
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -173,7 +173,7 @@ sleep 2
 else
       echo "Device not found"
       sleep 1
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo "Back to menu"
     sleep 1
     . ./launcher.sh

--- a/devices/nexus4/ubuntu/stablekeep.sh
+++ b/devices/nexus4/ubuntu/stablekeep.sh
@@ -14,9 +14,9 @@ if [ "$recoverymode"==Y -o "$recoverymode"==y -o "$recoverymode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|recovery$' ~/.AttachedDevices
+if grep 'device$\|recovery$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -31,14 +31,14 @@ if grep 'device$\|recovery$' ~/.AttachedDevices
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
     sleep 1
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus4/ubuntu/stablewipe.sh
+++ b/devices/nexus4/ubuntu/stablewipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus5/android/bootloader.sh
+++ b/devices/nexus5/android/bootloader.sh
@@ -22,9 +22,9 @@ if [ "$ulbootloader" = "1" ]; then
     echo "Detecting device"
     echo ""
     sleep 1
-    fastboot devices >~/.AttachedDevices
+    fastboot devices > /tmp/AttachedDevices
   fi
-    if grep 'device$\|fastboot$' ~/.AttachedDevices
+    if grep 'device$\|fastboot$' /tmp/AttachedDevices
     then
       echo "Device detected !"
       sleep 1
@@ -36,7 +36,7 @@ if [ "$ulbootloader" = "1" ]; then
       echo "Bootloader locked"
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       echo "Exiting script. Bye Bye"
       sleep 1
@@ -56,9 +56,9 @@ elif [ "$ulbootloader" = "2" ]; then
       echo "Detecting device"
       echo ""
       sleep 1
-      fastboot devices >~/.AttachedDevices
+      fastboot devices >/tmp/AttachedDevices
     fi
-      if grep 'device$\|fastboot$' ~/.AttachedDevices
+      if grep 'device$\|fastboot$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -73,19 +73,19 @@ elif [ "$ulbootloader" = "2" ]; then
         echo "Bootloader unlocked"
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         echo "Exiting script. Bye Bye"
         sleep 1
         exit
       fi
   elif [ "$ulbootloader" = "3" ]; then
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo "Quit"
       echo "Exiting script. Bye Bye"
 fi
 
 else
   echo "Device not found."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
   exit

--- a/devices/nexus5/android/cyanogenmod.sh
+++ b/devices/nexus5/android/cyanogenmod.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -99,7 +99,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -107,7 +107,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus5/android/cyanogenmodwogapps.sh
+++ b/devices/nexus5/android/cyanogenmodwogapps.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -87,7 +87,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -95,7 +95,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus5/android/factoryimage.sh
+++ b/devices/nexus5/android/factoryimage.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -42,7 +42,7 @@ fi
     sleep 2
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     rm -rf ./hammerhead-mob30y
     #rm -f ./*.tgz
     echo ""
@@ -52,6 +52,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus5/android/twrp.sh
+++ b/devices/nexus5/android/twrp.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -33,7 +33,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm -f ./*.img
     echo ""
     sleep 1
@@ -42,6 +42,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus5/ubuntu/stablewipe.sh
+++ b/devices/nexus5/ubuntu/stablewipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus7/android/bootloader.sh
+++ b/devices/nexus7/android/bootloader.sh
@@ -21,9 +21,9 @@ if [ "$ulbootloader" = "1" ]; then
     echo "Detecting device"
     echo ""
     sleep 1
-    fastboot devices >~/.AttachedDevices
+    fastboot devices > /tmp/AttachedDevices
   fi
-    if grep 'device$\|fastboot$' ~/.AttachedDevices
+    if grep 'device$\|fastboot$' /tmp/AttachedDevices
     then
       echo "Device detected !"
       sleep 1
@@ -35,7 +35,7 @@ if [ "$ulbootloader" = "1" ]; then
       echo "Bootloader locked"
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       echo "Exiting script. Bye Bye"
       sleep 1
@@ -54,9 +54,9 @@ elif [ "$ulbootloader" = "2" ]; then
       echo "Detecting device"
       echo ""
       sleep 1
-      fastboot devices >~/.AttachedDevices
+      fastboot devices >/tmp/AttachedDevices
     fi
-      if grep 'device$\|fastboot$' ~/.AttachedDevices
+      if grep 'device$\|fastboot$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -71,7 +71,7 @@ elif [ "$ulbootloader" = "2" ]; then
         echo "Bootloader unlocked"
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         echo "Exiting script. Bye Bye"
         sleep 1
@@ -84,5 +84,5 @@ fi
 
 else
   echo "Device not found."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
   exit

--- a/devices/nexus7/android/cyanogenmod.sh
+++ b/devices/nexus7/android/cyanogenmod.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -99,7 +99,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -107,7 +107,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus7/android/cyanogenmodwogapps.sh
+++ b/devices/nexus7/android/cyanogenmodwogapps.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -87,7 +87,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -95,7 +95,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus7/android/factoryimage.sh
+++ b/devices/nexus7/android/factoryimage.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -41,7 +41,7 @@ fi
     sleep 2
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     rm -rf ./razor-mob30x
     #rm -f ./*.tgz
     echo ""
@@ -51,6 +51,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus7/android/phoenixos.sh
+++ b/devices/nexus7/android/phoenixos.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -41,7 +41,7 @@ fi
     sleep 2
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     rm -rf ./Phoenix-neuxs7-flo-1.0.9-RC
     #rm -f ./*.tgz
     echo ""
@@ -51,6 +51,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus7/android/twrp.sh
+++ b/devices/nexus7/android/twrp.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices >/tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -33,7 +33,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm -f ./*.img
     echo ""
     sleep 1
@@ -42,6 +42,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus7/ubuntu/rc-proposedkeep.sh
+++ b/devices/nexus7/ubuntu/rc-proposedkeep.sh
@@ -14,9 +14,9 @@ if [ "$recoverymode"==Y -o "$recoverymode"==y -o "$recoverymode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|recovery$' ~/.AttachedDevices
+if grep 'device$\|recovery$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -31,14 +31,14 @@ if grep 'device$\|recovery$' ~/.AttachedDevices
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
     sleep 1
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus7/ubuntu/rc-proposedwipe.sh
+++ b/devices/nexus7/ubuntu/rc-proposedwipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus7/ubuntu/screencast.sh
+++ b/devices/nexus7/ubuntu/screencast.sh
@@ -29,11 +29,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -162,7 +162,7 @@ fi
 ssh $SSH_OPTS -C -c aes128-ctr phablet@localhost mirscreencast -m /var/run/mir_socket --stdout --cap-interval 10 -s 625 1000 |  mplayer -vf rotate=2 -framedrop -demuxer rawvideo -rawvideo fps=6:w=625:h=1000:format=rgba -
 echo ""
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -173,7 +173,7 @@ sleep 2
 else
       echo "Device not found"
       sleep 1
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo "Back to menu"
     sleep 1
     . ./launcher.sh

--- a/devices/nexus7/ubuntu/stablekeep.sh
+++ b/devices/nexus7/ubuntu/stablekeep.sh
@@ -14,9 +14,9 @@ if [ "$recoverymode"==Y -o "$recoverymode"==y -o "$recoverymode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|recovery$' ~/.AttachedDevices
+if grep 'device$\|recovery$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -31,14 +31,14 @@ if grep 'device$\|recovery$' ~/.AttachedDevices
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
     sleep 1
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus7/ubuntu/stablewipe.sh
+++ b/devices/nexus7/ubuntu/stablewipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus7deb/android/bootloader.sh
+++ b/devices/nexus7deb/android/bootloader.sh
@@ -22,9 +22,9 @@ if [ "$ulbootloader" = "1" ]; then
     echo "Detecting device"
     echo ""
     sleep 1
-    fastboot devices >~/.AttachedDevices
+    fastboot devices > /tmp/AttachedDevices
   fi
-    if grep 'device$\|fastboot$' ~/.AttachedDevices
+    if grep 'device$\|fastboot$' /tmp/AttachedDevices
     then
       echo "Device detected !"
       sleep 1
@@ -36,7 +36,7 @@ if [ "$ulbootloader" = "1" ]; then
       echo "Bootloader locked"
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       echo "Exiting script. Bye Bye"
       sleep 1
@@ -56,9 +56,9 @@ elif [ "$ulbootloader" = "2" ]; then
       echo "Detecting device"
       echo ""
       sleep 1
-      fastboot devices >~/.AttachedDevices
+      fastboot devices >/tmp/AttachedDevices
     fi
-      if grep 'device$\|fastboot$' ~/.AttachedDevices
+      if grep 'device$\|fastboot$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -73,7 +73,7 @@ elif [ "$ulbootloader" = "2" ]; then
         echo "Bootloader unlocked"
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         echo "Exiting script. Bye Bye"
         sleep 1
@@ -86,5 +86,5 @@ fi
 
 else
   echo "Device not found."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
   exit

--- a/devices/nexus7deb/android/cyanogenmod.sh
+++ b/devices/nexus7deb/android/cyanogenmod.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -99,7 +99,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -107,7 +107,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus7deb/android/cyanogenmodwogapps.sh
+++ b/devices/nexus7deb/android/cyanogenmodwogapps.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -87,7 +87,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -95,7 +95,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus7deb/android/factoryimage.sh
+++ b/devices/nexus7deb/android/factoryimage.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -42,7 +42,7 @@ fi
     sleep 2
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     rm -rf ./razorg-mob30x
     #rm -f ./*.tgz
     echo ""
@@ -52,6 +52,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus7deb/android/twrp.sh
+++ b/devices/nexus7deb/android/twrp.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -33,7 +33,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm -f ./*.img
     echo ""
     sleep 1
@@ -42,6 +42,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus7deb/ubuntu/stablewipe.sh
+++ b/devices/nexus7deb/ubuntu/stablewipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/nexus7tilapia/android/bootloader.sh
+++ b/devices/nexus7tilapia/android/bootloader.sh
@@ -22,9 +22,9 @@ if [ "$ulbootloader" = "1" ]; then
     echo "Detecting device"
     echo ""
     sleep 1
-    fastboot devices >~/.AttachedDevices
+    fastboot devices > /tmp/AttachedDevices
   fi
-    if grep 'device$\|fastboot$' ~/.AttachedDevices
+    if grep 'device$\|fastboot$' /tmp/AttachedDevices
     then
       echo "Device detected !"
       sleep 1
@@ -36,7 +36,7 @@ if [ "$ulbootloader" = "1" ]; then
       echo "Bootloader locked"
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       echo "Exiting script. Bye Bye"
       sleep 1
@@ -56,9 +56,9 @@ elif [ "$ulbootloader" = "2" ]; then
       echo "Detecting device"
       echo ""
       sleep 1
-      fastboot devices >~/.AttachedDevices
+      fastboot devices >/tmp/AttachedDevices
     fi
-      if grep 'device$\|fastboot$' ~/.AttachedDevices
+      if grep 'device$\|fastboot$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -73,7 +73,7 @@ elif [ "$ulbootloader" = "2" ]; then
         echo "Bootloader unlocked"
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         echo "Exiting script. Bye Bye"
         sleep 1
@@ -86,5 +86,5 @@ fi
 
 else
   echo "Device not found."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
   exit

--- a/devices/nexus7tilapia/android/cyanogenmod.sh
+++ b/devices/nexus7tilapia/android/cyanogenmod.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -99,7 +99,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -107,7 +107,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus7tilapia/android/cyanogenmodwogapps.sh
+++ b/devices/nexus7tilapia/android/cyanogenmodwogapps.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -87,7 +87,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -95,7 +95,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/nexus7tilapia/android/factoryimage.sh
+++ b/devices/nexus7tilapia/android/factoryimage.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -48,7 +48,7 @@ fi
     sleep 2
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     rm -rf ./nakasig-lmy47v
     #rm -f ./*.tgz
     echo ""
@@ -58,6 +58,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/nexus7tilapia/android/twrp.sh
+++ b/devices/nexus7tilapia/android/twrp.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -33,7 +33,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm -f ./*.img
     echo ""
     sleep 1
@@ -42,6 +42,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/oneplusone/android/bootloader.sh
+++ b/devices/oneplusone/android/bootloader.sh
@@ -23,9 +23,9 @@ if [ "$ulbootloader" = "1" ]; then
     echo "Detecting device"
     echo ""
     sleep 1
-    fastboot devices >~/.AttachedDevices
+    fastboot devices > /tmp/AttachedDevices
   fi
-    if grep 'device$\|fastboot$' ~/.AttachedDevices
+    if grep 'device$\|fastboot$' /tmp/AttachedDevices
     then
       echo "Device detected !"
       sleep 1
@@ -37,7 +37,7 @@ if [ "$ulbootloader" = "1" ]; then
       echo "Bootloader locked"
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo ""
       echo "Exiting script. Bye Bye"
       sleep 1
@@ -58,9 +58,9 @@ elif [ "$ulbootloader" = "2" ]; then
       echo "Detecting device"
       echo ""
       sleep 1
-      fastboot devices >~/.AttachedDevices
+      fastboot devices >/tmp/AttachedDevices
     fi
-      if grep 'device$\|fastboot$' ~/.AttachedDevices
+      if grep 'device$\|fastboot$' /tmp/AttachedDevices
       then
         echo "Device detected !"
         sleep 1
@@ -75,19 +75,19 @@ elif [ "$ulbootloader" = "2" ]; then
         echo "Bootloader unlocked"
         echo ""
         echo "Cleaning up.."
-        rm -f ~/.AttachedDevices
+        rm -f /tmp/AttachedDevices
         echo ""
         echo "Exiting script. Bye Bye"
         sleep 1
         exit
       fi
   elif [ "$ulbootloader" = "3" ]; then
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       echo "Quit"
       echo "Exiting script. Bye Bye"
 fi
 
 else
   echo "Device not found."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
   exit

--- a/devices/oneplusone/android/cyanogenmod.sh
+++ b/devices/oneplusone/android/cyanogenmod.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -99,7 +99,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -107,7 +107,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/oneplusone/android/cyanogenmodwogapps.sh
+++ b/devices/oneplusone/android/cyanogenmodwogapps.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-if grep 'device$\|fastboot$' ~/.AttachedDevices
+if grep 'device$\|fastboot$' /tmp/AttachedDevices
 then
   echo "Device detected !"
   sleep 1
@@ -84,7 +84,7 @@ then
   sleep 5
   echo ""
   echo "Cleaning up.."
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   echo ""
   sleep 1
   echo "Exiting script. Bye Bye"
@@ -92,7 +92,7 @@ then
 
 else
   echo "Device not found"
-  rm -f ~/.AttachedDevices
+  rm -f /tmp/AttachedDevices
   sleep 1
   echo ""
   echo "Back to menu"

--- a/devices/oneplusone/android/twrp.sh
+++ b/devices/oneplusone/android/twrp.sh
@@ -12,9 +12,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode"==y -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -33,7 +33,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm -f ./*.img
     echo ""
     sleep 1
@@ -42,6 +42,6 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     exit
   fi

--- a/devices/oneplusone/ubuntu/rc-proposedwipe.sh
+++ b/devices/oneplusone/ubuntu/rc-proposedwipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/oneplusone/ubuntu/stablewipe.sh
+++ b/devices/oneplusone/ubuntu/stablewipe.sh
@@ -13,9 +13,9 @@ if [ "$bootloadermode"==Y -o "$bootloadermode==y" -o "$bootloadermode"=="" ]; th
   echo "Detecting device"
   echo ""
   sleep 1
-  fastboot devices >~/.AttachedDevices
+  fastboot devices > /tmp/AttachedDevices
 fi
-  if grep 'device$\|fastboot$' ~/.AttachedDevices
+  if grep 'device$\|fastboot$' /tmp/AttachedDevices
   then
     echo "Device detected !"
     sleep 1
@@ -35,7 +35,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     echo ""
     sleep 1
     echo "Exiting script. Bye Bye"
@@ -43,7 +43,7 @@ fi
     exit
     else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/pro5/ubuntu/rc-proposedkeep.sh
+++ b/devices/pro5/ubuntu/rc-proposedkeep.sh
@@ -16,11 +16,11 @@ if [ "$developermode"==Y -o "$developermode"==y -o "$developermode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
   echo ""
   sleep 1
-  if grep 'device$\|device$' ~/.AttachedDevices
+  if grep 'device$\|device$' /tmp/AttachedDevices
   then
     echo ""
     echo "Device detected !"
@@ -54,7 +54,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-turbo.img
     echo ""
     sleep 1
@@ -63,7 +63,7 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/pro5/ubuntu/rc-proposedwipe.sh
+++ b/devices/pro5/ubuntu/rc-proposedwipe.sh
@@ -16,11 +16,11 @@ clear
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
   fi
     echo ""
     sleep 1
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -43,7 +43,7 @@ clear
       sleep 1
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       #rm recovery-turbo.img
       echo ""
       sleep 1
@@ -52,7 +52,7 @@ clear
       exit
     else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo ""
       echo "Back to menu"

--- a/devices/pro5/ubuntu/screencast.sh
+++ b/devices/pro5/ubuntu/screencast.sh
@@ -29,11 +29,11 @@ echo "Please enable developer mode on the device"
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
     echo ""
     sleep 1
   fi
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -163,7 +163,7 @@ fi
 ssh $SSH_OPTS -C -c aes128-ctr phablet@localhost mirscreencast -m /var/run/mir_socket --stdout --cap-interval 10 -s 360 640 |  mplayer -framedrop -demuxer rawvideo -rawvideo fps=6:w=360:h=640:format=rgba -
 echo ""
 echo "Back to menu"
-rm -f ~/.AttachedDevices
+rm -f /tmp/AttachedDevices
 sleep 2
 . ./launcher.sh
 
@@ -173,7 +173,7 @@ sleep 2
 [ -n "$SSH_RUNNING" ] || toggle_ssh false
 else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo "Back to menu"
     sleep 1

--- a/devices/pro5/ubuntu/stablekeep.sh
+++ b/devices/pro5/ubuntu/stablekeep.sh
@@ -16,11 +16,11 @@ if [ "$developermode"==Y -o "$developermode"==y -o "$developermode"=="" ]; then
   echo "Detecting device"
   echo ""
   sleep 1
-  adb devices >~/.AttachedDevices
+  adb devices > /tmp/AttachedDevices
 fi
   echo ""
   sleep 1
-  if grep 'device$\|device$' ~/.AttachedDevices
+  if grep 'device$\|device$' /tmp/AttachedDevices
   then
     echo ""
     echo "Device detected !"
@@ -54,7 +54,7 @@ fi
     sleep 1
     echo ""
     echo "Cleaning up.."
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     #rm recovery-turbo.img
     echo ""
     sleep 1
@@ -63,7 +63,7 @@ fi
     exit
   else
     echo "Device not found"
-    rm -f ~/.AttachedDevices
+    rm -f /tmp/AttachedDevices
     sleep 1
     echo ""
     echo "Back to menu"

--- a/devices/pro5/ubuntu/stablewipe.sh
+++ b/devices/pro5/ubuntu/stablewipe.sh
@@ -16,11 +16,11 @@ clear
     echo "Detecting device"
     echo ""
     sleep 1
-    adb devices >~/.AttachedDevices
+    adb devices > /tmp/AttachedDevices
   fi
     echo ""
     sleep 1
-    if grep 'device$\|device$' ~/.AttachedDevices
+    if grep 'device$\|device$' /tmp/AttachedDevices
     then
       echo ""
       echo "Device detected !"
@@ -43,7 +43,7 @@ clear
       sleep 1
       echo ""
       echo "Cleaning up.."
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       #rm recovery-turbo.img
       echo ""
       sleep 1
@@ -52,7 +52,7 @@ clear
       exit
     else
       echo "Device not found"
-      rm -f ~/.AttachedDevices
+      rm -f /tmp/AttachedDevices
       sleep 1
       echo ""
       echo "Back to menu"


### PR DESCRIPTION
I moved the temporary of the list attached devices (~/.AttachedDevices) to /tmp/AttachedDevice because I think it's better to put it to /tmp. I think if the script crash unexpectally, the file don't contaminate the homes of the users 
