### PR TITLE
launcher.sh is already executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Usage
 ```
 $ git clone https://github.com/MariusQuabeck/magic-device-tool.git
 $ cd magic-device-tool
-$ chmod +x launcher.sh
 $ ./launcher.sh
 ```
 


### PR DESCRIPTION
If you look at this screenshot, you can see that `launcher.sh` is already executable:

![screenshot 2016-10-24 at 6 51 21 pm](https://cloud.githubusercontent.com/assets/3689821/19668114/004b24d4-9a1b-11e6-93f6-749e520ee736.png)

I even looked at this locally:

```
-rwxrwxr-x  1 ubuntu ubuntu 4.0K Oct 24 18:50 launcher.sh
```

This removes the unneeded instruction from README.md.
