### PR TITLE
Fix trivial typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![alt text](https://raw.githubusercontent.com/MariusQuabeck/magic-device-tool/master/logo.png "magic-device-tool logo")
 
 
-A simple and feature full batch tool to handle installing/replacing Operating Systems (Ubuntu Phone / Ubuntu Touch, Android, CyanogenMod, Maru OS , Sailfish OS and Phoenix OS) on your mobile devices.
+A simple and feature full batch tool to handle installing/replacing Operating Systems (Ubuntu Phone / Ubuntu Touch, Android, CyanogenMod, Maru OS, Sailfish OS, and Phoenix OS) on your mobile devices.
 
 Contact
 -------
@@ -55,7 +55,7 @@ Supported devices
 - Asus Nexus 7 2013 WiFi (flo)
 - Asus Nexus 7 2013 LTE (deb)
 - Asus Nexus 7 2012 3G (tilapia)
-- Asus Nexus 7 2012 Wifi (grouper)
+- Asus Nexus 7 2012 WiFi (grouper)
 - Samsung Nexus 10 (manta)
 - OnePlus One (bacon)
 - Fairphone 2 (FP2) !!May not work!!


### PR DESCRIPTION
1. You put a space between `Maru OS` and `,` and since it doesn't exist elsewhere, this corrects it.
2. This is sort of nit-picky, but I added an [Oxford Comma](https://www.grammarly.com/blog/what-is-the-oxford-comma-and-why-do-people-care-so-much-about-it/). I prefer using it, and it's just a matter of preference, but in this case it makes it less confusing.
3. The [correct spelling](https://en.wikipedia.org/wiki/Wi-Fi) of `Wifi` is `WiFi`, or `Wi-Fi`, but to me putting the dash in is sort of like putting the dash in `e-mail`, which you seem to not care too much about, so I'll leave that as `WiFi`.
