### PR TITLE
Update link to LineageOS nexus 4 image

### DIFF
--- a/devices/nexus4/android/lineageos.sh
+++ b/devices/nexus4/android/lineageos.sh
@@ -36,7 +36,7 @@ then
   echo "Downloading LineageOS 14.1.."
   echo ""
   sleep 1
-  wget -c --quiet --show-progress --tries=10 -P $HOME/.cache/magic-device-tool/ https://mirrorbits.lineageos.org/full/mako/20170720/lineage-14.1-20170720-nightly-mako-signed.zip
+  wget -c --quiet --show-progress --tries=10 -P $HOME/.cache/magic-device-tool/ https://mirrorbits.lineageos.org/full/mako/20170824/lineage-14.1-20170824-nightly-mako-signed.zip
   echo ""
   echo "Downloading Open Gapps.."
   echo ""
@@ -72,7 +72,7 @@ then
   echo "Ignore that prompt, the tool will take care of the installation"
   echo ""
   echo "  → LineageOS 14.1 zip "
-  adb push -p $HOME/.cache/magic-device-tool/lineage-14.1-20170720-nightly-mako-signed.zip /sdcard/
+  adb push -p $HOME/.cache/magic-device-tool/lineage-14.1-20170824-nightly-mako-signed.zip /sdcard/
   echo ""
   echo "  → open gapps zip"
   adb push -p $HOME/.cache/magic-device-tool/open_gapps-arm-7.1-nano-20170603.zip /sdcard/
@@ -82,7 +82,7 @@ then
   echo ""
   echo "Installing LineageOS.."
   echo ""
-  adb shell twrp install /sdcard/lineage-14.1-20170720-nightly-mako-signed.zip
+  adb shell twrp install /sdcard/lineage-14.1-20170824-nightly-mako-signed.zip
   sleep 1
   echo ""
   echo "Installing Open GApps.."

--- a/devices/nexus4/android/lineageoswogapps.sh
+++ b/devices/nexus4/android/lineageoswogapps.sh
@@ -36,7 +36,7 @@ then
   echo "Downloading LineageOS 14.1 .."
   echo ""
   sleep 1
-  wget -c --quiet --show-progress --tries=10 -P $HOME/.cache/magic-device-tool/ https://mirrorbits.lineageos.org/full/mako/20170720/lineage-14.1-20170720-nightly-mako-signed.zip
+  wget -c --quiet --show-progress --tries=10 -P $HOME/.cache/magic-device-tool/ https://mirrorbits.lineageos.org/full/mako/20170824/lineage-14.1-20170824-nightly-mako-signed.zip
   echo ""
   sleep 2
   clear
@@ -68,14 +68,14 @@ then
   echo "Ignore that prompt, the tool will take care of the installation"
   echo ""
   echo "  → LineageOS 14.1 zip "
-  adb push -p $HOME/.cache/magic-device-tool/lineage-14.1-20170720-nightly-mako-signed.zip /sdcard/
+  adb push -p $HOME/.cache/magic-device-tool/lineage-14.1-20170824-nightly-mako-signed.zip /sdcard/
   echo ""
   echo "========================================="
   sleep 1
   echo ""
   echo "Installing LineageOS.."
   echo ""
-  adb shell twrp install /sdcard/lineage-14.1-20170720-nightly-mako-signed.zip
+  adb shell twrp install /sdcard/lineage-14.1-20170824-nightly-mako-signed.zip
   sleep 1
   echo ""
   echo "Wipe cache.."


### PR DESCRIPTION
Thanks for this awesome tool Marius and team.

I recently tried to flash Lineage to my Nexus 4 (mako) device using MDT (via snap), but the install failed because the link to the LineageOS image was returning a "not found" error. Consequently the zip was not being downloaded. So I just updated the link to the LineageOS image and ran the script directly rather than via snap, and it worked like a charm. Here are my changes in case you want to pull them in.

Cheers,
Dan