### PR TITLE
scrape latest zip from lineage mako page

### DIFF
--- a/devices/nexus4/android/lineageos.sh
+++ b/devices/nexus4/android/lineageos.sh
@@ -36,7 +36,9 @@ then
   echo "Downloading LineageOS 14.1.."
   echo ""
   sleep 1
-  wget -c --quiet --show-progress --tries=10 -P $HOME/.cache/magic-device-tool/ https://mirrorbits.lineageos.org/full/mako/20170831/lineage-14.1-20170831-nightly-mako-signed.zip
+  LOSLINK=$(wget -qO- https://download.lineageos.org/mako | sed -n 's/.*href="\([^"]*\.zip\).*/\1/p' | head -n1)
+  LOSZIP=${LOSLINK##*/}
+  wget -c --quiet --show-progress --tries=10 -P $HOME/.cache/magic-device-tool/ $LOSLINK
   echo ""
   echo "Downloading Open Gapps.."
   echo ""
@@ -72,7 +74,8 @@ then
   echo "Ignore that prompt, the tool will take care of the installation"
   echo ""
   echo "  → LineageOS 14.1 zip "
-  adb push -p $HOME/.cache/magic-device-tool/lineage-14.1-20170831-nightly-mako-signed.zip /sdcard/
+  LOSPATH="$HOME/.cache/magic-device-tool/$LOSZIP"
+  adb push -p $LOSPATH /sdcard/
   echo ""
   echo "  → open gapps zip"
   adb push -p $HOME/.cache/magic-device-tool/open_gapps-arm-7.1-nano-20170603.zip /sdcard/
@@ -82,7 +85,8 @@ then
   echo ""
   echo "Installing LineageOS.."
   echo ""
-  adb shell twrp install /sdcard/lineage-14.1-20170831-nightly-mako-signed.zip
+  INSTALLPATH="/sdcard/$LOSZIP"
+  adb shell twrp install $INSTALLPATH
   sleep 1
   echo ""
   echo "Installing Open GApps.."


### PR DESCRIPTION
Marius, you had mentioned [your frustration](https://github.com/MariusQuabeck/magic-device-tool/pull/105#issuecomment-326189873) at there not being a "latest.zip" link for LineageOS ROMs. 

What do you think of this solution to that problem?

Rather than having to manually change the scripts to reference the latest zips, I've added some code to automatically parse the LineageOS mako web page (https://download.lineageos.org/mako) and fetch the most recent zip. I've only done this for one nexus4 script, but of course the same thing could easily be done for the lineage scripts of any device. If it's something you like and want to include, I can help update the scripts for other devices. 