### PR TITLE
Correct the action prompt in ubports-backup.sh

### DIFF
--- a/devices/generic/ubuntu/ubports-backup.sh
+++ b/devices/generic/ubuntu/ubports-backup.sh
@@ -2,7 +2,7 @@
 
 function wait_for_user() {
 
-    read -p "Press a key to continue..." tmp 
+    read -p "Hit Enter to continue..." tmp 
 
 }
 


### PR DESCRIPTION
Press a key does not continue on this read bash prompt, should be the Enter key instead.